### PR TITLE
ci: remove magic-nix-cache-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: nix build
         run: nix build .#


### PR DESCRIPTION
remove magic-nix-cache-action because it is EOL (https://dtr.mn/magic-nix-cache-eol)