### PR TITLE
smartvmi: add gtest dependency to build test successfully

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
     "smartvmi": {
       "flake": false,
       "locked": {
-        "lastModified": 1747047869,
-        "narHash": "sha256-fhUdRj79vKtXb7dYFQUTWbCfcEgrxRFZK5OT8q+qQz4=",
+        "lastModified": 1747648126,
+        "narHash": "sha256-bGXS8QyfTY5784qkyXA+/E0ZB+3AOWpo25uckLFQtkk=",
         "owner": "lbeierlieb",
         "repo": "smartvmi",
-        "rev": "30f3c7e895556c547b864ca271646b2c767621e9",
+        "rev": "7467697abb0f685613cd7351a5b14b7e2f700ba7",
         "type": "github"
       },
       "original": {
         "owner": "lbeierlieb",
         "repo": "smartvmi",
-        "rev": "30f3c7e895556c547b864ca271646b2c767621e9",
+        "rev": "7467697abb0f685613cd7351a5b14b7e2f700ba7",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       flake = false;
     };
     smartvmi = {
-      url = "github:lbeierlieb/smartvmi?rev=30f3c7e895556c547b864ca271646b2c767621e9";
+      url = "github:lbeierlieb/smartvmi?rev=7467697abb0f685613cd7351a5b14b7e2f700ba7";
       flake = false;
     };
   };

--- a/smartvmi/build_plugin.nix
+++ b/smartvmi/build_plugin.nix
@@ -5,6 +5,7 @@
 , # deps
   cmake
 , fmt
+, gtest
 , jsoncpp
 , pkg-config
 , tclap
@@ -37,6 +38,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
+    gtest
     pkg-config
   ];
 }

--- a/smartvmi/build_vmicore.nix
+++ b/smartvmi/build_vmicore.nix
@@ -9,6 +9,7 @@
 , fuse
 , fmt
 , glib
+, gtest
 , json_c
 , libkvmi
 , libvirt
@@ -63,6 +64,7 @@ stdenv.mkDerivation {
       corrosion
       cxxbridge-cmd # for corrosion
       flex
+      gtest
       pkg-config
       rustc
     ]


### PR DESCRIPTION
previously, the Nix packaging from this repository assumed that the CMakeLists.txt are modified in such a way that the tests are not built by default.
https://github.com/GDATASoftwareAG/smartvmi/pull/154#discussion_r2073328561 requested to remove the behavior. The suggestion to build the CMakeLists.txt from the src folder instead of the top level is great, but after a few tries I did not find the correct derivation settings (e.g., by setting cmakeDir) and chose to just build the tests as well. This commit switches the smartvmi source to a commit without the CMakeLists.txt changes and adds gtest to both vmicore and the plugins (required dependency of the test code).