### PR TITLE
flake: use gdata repo for smartvmi sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,16 @@
     "smartvmi": {
       "flake": false,
       "locked": {
-        "lastModified": 1747648126,
-        "narHash": "sha256-bGXS8QyfTY5784qkyXA+/E0ZB+3AOWpo25uckLFQtkk=",
-        "owner": "lbeierlieb",
+        "lastModified": 1748862580,
+        "narHash": "sha256-4q1NIOrniioS14Otr4EsX/SjoGZjYLOVL7BGlNB1E9k=",
+        "owner": "GDATASoftwareAg",
         "repo": "smartvmi",
-        "rev": "7467697abb0f685613cd7351a5b14b7e2f700ba7",
+        "rev": "9c1e79f870c4562350a5a29f0f07061dd12a7626",
         "type": "github"
       },
       "original": {
-        "owner": "lbeierlieb",
+        "owner": "GDATASoftwareAg",
         "repo": "smartvmi",
-        "rev": "7467697abb0f685613cd7351a5b14b7e2f700ba7",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       flake = false;
     };
     smartvmi = {
-      url = "github:lbeierlieb/smartvmi?rev=7467697abb0f685613cd7351a5b14b7e2f700ba7";
+      url = "github:GDATASoftwareAg/smartvmi";
       flake = false;
     };
   };


### PR DESCRIPTION
previously, the official gdata smartvmi repo
(https://github.com/GDATASoftwareAG/smartvmi) did not contain the changes necessary to build smartvmi with Nix (without big workarounds). Now, the changes are merged
(https://github.com/GDATASoftwareAG/smartvmi/pull/154) and we can use the sources for the Nix build!